### PR TITLE
fix calculation of sticky footer when heights differ from default

### DIFF
--- a/scss/_footer.scss
+++ b/scss/_footer.scss
@@ -4,7 +4,7 @@ footer.sticky-footer {
   bottom: 0;
 
   width: 100%;
-  height: 56px;
+  height: $sticky-footer-height;
 
   background-color: $gray-200;
 

--- a/scss/_global.scss
+++ b/scss/_global.scss
@@ -10,18 +10,18 @@ body {
 }
 
 body.sticky-footer {
-  margin-bottom: 56px;
+  margin-bottom: $sticky-footer-height;
   .content-wrapper {
-    min-height: calc(100vh - 56px - 56px);
+    min-height: calc(100vh - #{$sticky-footer-height} - #{$navbar-base-height});
   }
 }
 
 body.fixed-nav {
-  padding-top: 56px;
+  padding-top: $navbar-base-height;
 }
 
 .content-wrapper {
-  min-height: calc(100vh - 56px);
+  min-height: calc(100vh - #{$sticky-footer-height});
   padding-top: 1rem;
 }
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -30,3 +30,5 @@ $navbar-base-height: 56px;
 $sidenav-base-width: 250px;
 // Change below variable to change the width of the sidenav when collapsed
 $sidenav-collapsed-width: 55px;
+// Change below variable to change the height of the sticky footer
+$sticky-footer-height: 56px;


### PR DESCRIPTION
As of now, there is a variable `$navbar-base-height` for navbars which differ from the default height of 56px. However, changing this value does not result in the right padding, margin and height because the height of the navbar and the sticky-footer (56px) is still hard-coded in some places.

Introduces a new variable `$sticky-footer-height` which can be set if the height of the footer is different from the default 56px.
Also, `$navbar-base-height` is considered in the calculation of the content's height.

Feel free to provide some feedback.