### PR TITLE
Upgrade bootstrap & chart.js dependencies to resolve vulnerabilties

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -597,12 +597,12 @@
             }
         },
         "chart.js": {
-            "version": "2.7.1",
-            "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-2.7.1.tgz",
-            "integrity": "sha512-pX1oQAY86MiuyZ2hY593Acbl4MLHKrBBhhmZ1YqSadzQbbsBE2rnd6WISoHjIsdf0WDeC0hbePYCz2ZxkV8L+g==",
+            "version": "2.7.2",
+            "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-2.7.2.tgz",
+            "integrity": "sha512-90wl3V9xRZ8tnMvMlpcW+0Yg13BelsGS9P9t0ClaDxv/hdypHDr/YAGf+728m11P5ljwyB0ZHfPKCapZFqSqYA==",
             "requires": {
                 "chartjs-color": "2.2.0",
-                "moment": "2.18.1"
+                "moment": "2.22.2"
             }
         },
         "chartjs-color": {
@@ -4286,9 +4286,9 @@
             }
         },
         "moment": {
-            "version": "2.18.1",
-            "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
-            "integrity": "sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8="
+            "version": "2.22.2",
+            "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
+            "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y="
         },
         "ms": {
             "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -409,9 +409,9 @@
             }
         },
         "bootstrap": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.0.0.tgz",
-            "integrity": "sha512-gulJE5dGFo6Q61V/whS6VM4WIyrlydXfCgkE+Gxe5hjrJ8rXLLZlALq7zq2RPhOc45PSwQpJkrTnc2KgD6cvmA=="
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.1.2.tgz",
+            "integrity": "sha512-3bP609EdMc/8EwgGp8KgpN8HwnR4V4lZ9CTi5pImMrXNxpkw7dK1B05aMwQWpG1ZWmTLlBSN/uzkuz5GsmQNFA=="
         },
         "brace-expansion": {
             "version": "1.1.8",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "url": "https://github.com/BlackrockDigital/startbootstrap-sb-admin.git"
     },
     "dependencies": {
-        "bootstrap": "4.0.0",
+        "bootstrap": "^4.1.2",
         "chart.js": "2.7.1",
         "datatables.net-bs4": "1.10.16",
         "font-awesome": "4.7.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     },
     "dependencies": {
         "bootstrap": "^4.1.2",
-        "chart.js": "2.7.1",
+        "chart.js": "^2.7.2",
         "datatables.net-bs4": "1.10.16",
         "font-awesome": "4.7.0",
         "jquery": "3.3.1",


### PR DESCRIPTION
2 vulnerabilities were found in the dependencies:

- Bootstrap@4.0.0 medium (xss) 
https://snyk.io/vuln/npm:bootstrap:20180529

- Chart.js@2.7.1
https://snyk.io/vuln/npm:moment:20170905

I've upgraded to bootstrap@4.1.2 and chart.js@2.7.2

Regards.

